### PR TITLE
Impl Raft leadership responsibilities & replication stream actor.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4"
 prost = "0.5"
 prost-derive = "0.5"
 rand = "0.6"
+tokio = "0.1"
 
 [build-dependencies]
 prost-build = "0.5"

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,11 @@ pub struct Config {
     /// This value is randomly generated based on default confguration or a given min & max.
     pub election_timeout_millis: u64,
     /// The heartbeat interval at which leaders will send heartbeats to followers.
+    ///
+    /// **NOTE WELL:** it is very important that this value be greater than the amount if time
+    /// it will take on average for heartbeat frames to be sent between nodes. No data processing
+    /// is performed for heartbeats, so the main item of concern here is network latency. This
+    /// value is also used as the default timeout for sending heartbeats.
     pub heartbeat_interval: u64,
     /// The maximum number of entries per payload allowed to be transmitted during replication.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod storage;
 
 pub use crate::{
     raft::{
-        ClientRpcOut,
+        ClientRequest,
         NodeId,
         Raft, RaftRpcIn, RaftRpcOut,
     },

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -13,7 +13,7 @@ use crate::{
     config::Config,
     error::RaftError,
     proto,
-    replication::{InstallSnapshot, InstallSnapshotResponse, RSEvent},
+    replication::{RSNeedsSnapshot, RSNeedsSnapshotResponse, RSRateUpdate, RSRevertToFollower},
     storage::{
         self, StorageResult, AppendLogEntries, AppendLogEntriesData,
         ApplyEntriesToStateMachine, GetLogEntries, InitialState, SaveHardState,
@@ -827,22 +827,34 @@ impl<S: RaftStorage> Actor for Raft<S> {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // Replication Streams ///////////////////////////////////////////////////////////////////////////
 
-// RSEvent ///////////////////////////////////////////////////////////////////
+// RSRateUpdate //////////////////////////////////////////////////////////////
 
-impl<S: RaftStorage> Handler<RSEvent> for Raft<S> {
+impl<S: RaftStorage> Handler<RSRateUpdate> for Raft<S> {
     type Result = ();
 
     /// Handle events from replication streams.
-    fn handle(&mut self, msg: RSEvent, ctx: &mut Self::Context) {
+    fn handle(&mut self, msg: RSRateUpdate, ctx: &mut Self::Context) {
     }
 }
 
-impl <S: RaftStorage> Handler<InstallSnapshot> for Raft<S> {
-    type Result = ResponseActFuture<Self, InstallSnapshotResponse, ()>;
+// RSNeedsSnapshot ///////////////////////////////////////////////////////////
 
-    /// Handle events from replication streams for installing snapshots.
-    fn handle(&mut self, msg: InstallSnapshot, ctx: &mut Self::Context) -> Self::Result {
+impl <S: RaftStorage> Handler<RSNeedsSnapshot> for Raft<S> {
+    type Result = ResponseActFuture<Self, RSNeedsSnapshotResponse, ()>;
+
+    /// Handle events from replication streams requesting for snapshot info.
+    fn handle(&mut self, msg: RSNeedsSnapshot, ctx: &mut Self::Context) -> Self::Result {
         Box::new(fut::FutureResult::from(Err(())))
+    }
+}
+
+// RSRevertToFollower ////////////////////////////////////////////////////////
+
+impl <S: RaftStorage> Handler<RSRevertToFollower> for Raft<S> {
+    type Result = ();
+
+    /// Handle events from replication streams for when this node needs to revert to follower state.
+    fn handle(&mut self, msg: RSRevertToFollower, ctx: &mut Self::Context) {
     }
 }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -13,7 +13,7 @@ use crate::{
     config::Config,
     error::RaftError,
     proto,
-    replication::{RSNeedsSnapshot, RSNeedsSnapshotResponse, RSRateUpdate, RSRevertToFollower},
+    replication::{RSNeedsSnapshot, RSNeedsSnapshotResponse, RSRateUpdate, RSRevertToFollower, RSUpdateMatchIndex},
     storage::{
         self, StorageResult, AppendLogEntries, AppendLogEntriesData,
         ApplyEntriesToStateMachine, GetLogEntries, InitialState, SaveHardState,
@@ -855,6 +855,16 @@ impl <S: RaftStorage> Handler<RSRevertToFollower> for Raft<S> {
 
     /// Handle events from replication streams for when this node needs to revert to follower state.
     fn handle(&mut self, msg: RSRevertToFollower, ctx: &mut Self::Context) {
+    }
+}
+
+// RSUpdateMatchIndex ////////////////////////////////////////////////////////
+
+impl <S: RaftStorage> Handler<RSUpdateMatchIndex> for Raft<S> {
+    type Result = ();
+
+    /// Handle events from a replication stream which updates the target node's match index.
+    fn handle(&mut self, msg: RSUpdateMatchIndex, ctx: &mut Self::Context) {
     }
 }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -13,7 +13,11 @@ use crate::{
     config::Config,
     error::RaftError,
     proto,
-    replication::{RSNeedsSnapshot, RSNeedsSnapshotResponse, RSRateUpdate, RSRevertToFollower, RSUpdateMatchIndex},
+    replication::{
+        ReplicationStream, RSReplicate,
+        RSNeedsSnapshot, RSNeedsSnapshotResponse,
+        RSRateUpdate, RSRevertToFollower, RSUpdateMatchIndex,
+    },
     storage::{
         self, StorageResult, AppendLogEntries, AppendLogEntriesData,
         ApplyEntriesToStateMachine, GetLogEntries, InitialState, SaveHardState,
@@ -29,7 +33,7 @@ pub type NodeId = u64;
 
 /// The state of the Raft node.
 #[derive(Eq, PartialEq)]
-pub(crate) enum NodeState {
+enum NodeState {
     /// A non-standard Raft state indicating that the node is initializing.
     Initializing,
     /// A non-standard Raft state indicating that the node is awaiting an admin command to begin.
@@ -62,21 +66,23 @@ pub(crate) enum NodeState {
 /// Volatile state specific to the Raft leader.
 ///
 /// This state is reinitialized after an election.
+#[derive(Default, Eq, PartialEq)]
+struct LeaderState {
+    /// A mapping of node IDs the replication state of the target node.
+    pub nodes: BTreeMap<NodeId, ReplicationState>,
+}
+
+/// A struct tracking the state of a replication stream from the perspective of the Raft actor.
 #[derive(Eq, PartialEq)]
-pub(crate) struct LeaderState {
-    /// A mapping of node IDs to the index of the next log entry to send.
-    // next_index: BTreeMap<NodeId, u64>,
-    // TODO: ^^^ replace this with a better tracking mechanism for replication rate, addr of
-    // replication stream, and subsume match index as well.
-    /// A mapping of node IDs to the highest log entry index known to be replicated thereof.
-    ///
-    /// Each entry is initialized to 0, and increases per the Raft data replication protocol.
-    match_index: BTreeMap<NodeId, u64>,
+struct ReplicationState {
+    pub match_index: u64,
+    pub is_at_line_rate: bool,
+    pub addr: Recipient<RSReplicate>,
 }
 
 /// Volatile state specific to a Raft node in candidate state.
 #[derive(Eq, PartialEq)]
-pub(crate) struct CandidateState {
+struct CandidateState {
     /// Current outstanding requests to peer nodes by node ID.
     requests: BTreeMap<NodeId, SpawnHandle>,
     /// The number of votes which have been granted by peer nodes.
@@ -396,48 +402,15 @@ impl<S> Raft<S> where S: RaftStorage {
 
     /// Transition to the Raft leader state.
     ///
-    /// Once a node becomes the Raft cluster leader, its behavior will be a bit different:
+    /// Once a node becomes the Raft cluster leader, its behavior will be a bit different. Upon
+    /// election:
     ///
-    /// - Upon election, send initial empty AppendEntries RPCs (heartbeats) to each server; repeat
-    /// during idle periods to prevent election timeouts, per §5.2.
-    /// - If command received from client, append entry to local log, replicate to other nodes,
-    /// and then apply to state machine. This implementation allows clients to specify when they
-    /// want to receive a response. Options are Committed, or Applied. Committed means the client
-    /// will receive a response once the command has been appended to the leader's log and a
-    /// majority of the logs in the cluster, which aligns with Raft's definition of a committed
-    /// log. Applied means that the committed log has been successfully applied to the state
-    /// machine and flushed to disk, per Raft's definition.
-    /// TODO: impl this ^^^
-    /// -
+    /// - Each cluster member gets a `ReplicationStream` actor spawned. Addr is retained.
+    /// - Initial AppendEntries RPCs (heartbeats) are sent to each cluster member, and is repeated
+    /// during idle periods to prevent election timeouts, per §5.2. This is handled by the
+    /// `ReplicationStream` actors.
     ///
-    /// - each member gets a `ReplicationStream` actor spawned. Addr is retained.
-    /// - leader state calls add_stream (retaining the handle) on an mpsc receiver. The sender will
-    /// be retained and used for sending client write requests. Client write operations will clone the
-    /// sender, and enqueue themselves in order to enter the processing queue.
-    /// - client writes are queued. Oneshot msg receiver will be returned as future, sender will
-    /// be enqueued along with request data. This is sent along on the retained sender from above.
-    /// - as client requests are processed, they are immediately appended to the log. Once an event
-    /// is appended to the log, the updated index is sent over to all replication streams along with
-    /// the Raft's committed index and a copy of the logs which were written as part of that update.
-    /// This optimizes replication speed for replication streams which are running at line rate.
-    /// - replication streams will request entries from the Raft if they are not running at line
-    /// rate. After every successful AppendEntries RPC sent to a follower from the replication
-    /// stream, it will send an event to the Raft of the last index sent & whether it is at line rate or not.
-    /// The Raft will also update its committed_index based on these replication event messages.
-    /// - if a replication stream needs to snapshot a follower, it will send a message to the Raft
-    /// indicating that such is needed. The Raft node will perform the snapshot & will send the snapshot
-    /// info back to the replication stream.
-    ///
-    /// For the client path:
-    /// - the client's response channel can be persisted based on whether it needs Committed or
-    /// Applied state for messages.
-    /// - Every time the committed index is updated based on replication events, the BTreeMap storing
-    /// the channels will be checked for any keys which are <= new committed index. For anything which matches,
-    /// they will be removed and their response will be sent.
-    /// - As part of updating the committed index, after client responses have been sent, the logs
-    /// which need to be applied will be sent over to the storage engine to be applied.
-    /// - Once the committed logs have been applied to the state machine, the client requests which
-    /// are awaiting Applied state for their requests will be evaluated and responded to.
+    /// See the `ClientRequest` handler for more details on the write path for client requests.
     fn become_leader(&mut self, ctx: &mut Context<Self>) {
         // Cleanup previous state & ensure we've cancelled the election timeout system.
         self.cleanup_state(ctx);
@@ -445,13 +418,26 @@ impl<S> Raft<S> where S: RaftStorage {
             ctx.cancel_future(handle);
         }
 
-        // Send initial set of heartbeats to followers to establish leadership.
+        // Prep new leader state.
+        let mut new_state = LeaderState::default();
 
-        // Start the heartbeat stream to followers.
+        // Spawn new replication stream actors.
+        for target in self.members.iter().filter(|elem| *elem != &self.id) {
+            // Build the replication stream for the target member.
+            let rs = ReplicationStream::new(
+                self.id, *target, self.current_term, self.config.clone(),
+                self.last_log_index, self.last_log_term, self.commit_index,
+                ctx.address(), self.out.clone(), self.storage.clone().recipient(),
+            );
+            let addr = rs.start(); // Start the actor on the same thread.
+
+            // Retain the addr of the replication stream.
+            let state = ReplicationState{match_index: self.last_log_index, is_at_line_rate: true, addr: addr.recipient()};
+            new_state.nodes.insert(*target, state);
+        }
 
         // Initialize new state as leader.
-
-        // TODO: finish this up.
+        self.state = NodeState::Leader(new_state);
     }
 
     /// Clean up the current Raft state.
@@ -833,7 +819,7 @@ impl<S: RaftStorage> Handler<RSRateUpdate> for Raft<S> {
     type Result = ();
 
     /// Handle events from replication streams.
-    fn handle(&mut self, msg: RSRateUpdate, ctx: &mut Self::Context) {
+    fn handle(&mut self, _msg: RSRateUpdate, _ctx: &mut Self::Context) {
     }
 }
 
@@ -843,7 +829,7 @@ impl <S: RaftStorage> Handler<RSNeedsSnapshot> for Raft<S> {
     type Result = ResponseActFuture<Self, RSNeedsSnapshotResponse, ()>;
 
     /// Handle events from replication streams requesting for snapshot info.
-    fn handle(&mut self, msg: RSNeedsSnapshot, ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, _msg: RSNeedsSnapshot, _ctx: &mut Self::Context) -> Self::Result {
         Box::new(fut::FutureResult::from(Err(())))
     }
 }
@@ -854,7 +840,7 @@ impl <S: RaftStorage> Handler<RSRevertToFollower> for Raft<S> {
     type Result = ();
 
     /// Handle events from replication streams for when this node needs to revert to follower state.
-    fn handle(&mut self, msg: RSRevertToFollower, ctx: &mut Self::Context) {
+    fn handle(&mut self, _msg: RSRevertToFollower, _ctx: &mut Self::Context) {
     }
 }
 
@@ -864,7 +850,7 @@ impl <S: RaftStorage> Handler<RSUpdateMatchIndex> for Raft<S> {
     type Result = ();
 
     /// Handle events from a replication stream which updates the target node's match index.
-    fn handle(&mut self, msg: RSUpdateMatchIndex, ctx: &mut Self::Context) {
+    fn handle(&mut self, _msg: RSUpdateMatchIndex, _ctx: &mut Self::Context) {
     }
 }
 
@@ -945,24 +931,58 @@ impl<S: RaftStorage> Handler<RaftRpcIn> for Raft<S> {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
-// ClientRpcOut //////////////////////////////////////////////////////////////////////////////////
+// ClientRequest /////////////////////////////////////////////////////////////////////////////////
 
-/// An actix message holding a Raft RPC frame to be sent outbound to a peer Raft node.
-pub struct ClientRpcOut;
+/// An actix message representing a client request to mutate the data of this Raft cluster.
+pub struct ClientRequest;
 
-impl Message for ClientRpcOut {
+impl Message for ClientRequest{
     type Result = Result<(), ()>;
+}
+
+impl<S: RaftStorage> Handler<ClientRequest> for Raft<S> {
+    type Result = actix::ResponseActFuture<Self, (), ()>;
+
+    /// Handle a client request to mutate the data of the Raft cluster.
+    ///
+    ///  - If command received from client, append entry to local log, replicate to other nodes,
+    /// and then apply to state machine. This implementation allows clients to specify when they
+    /// want to receive a response. Options are Committed, or Applied. Committed means the client
+    /// will receive a response once the command has been appended to the leader's log and a
+    /// majority of the logs in the cluster, which aligns with Raft's definition of a committed
+    /// log. Applied means that the committed log has been successfully applied to the state
+    /// machine and flushed to disk, per Raft's definition.
+    /// TODO: impl this ^^^
+    ///
+    /// ----
+    ///
+    /// - Client writes are immediately processed, but their response channel is queued. Oneshot
+    /// msg receiver will be returned as future, sender will be enqueued for response condition
+    /// to be met.
+    /// - As client requests are processed, they are immediately appended to the log. Once an event
+    /// is appended to the log, the updated index is sent over to all replication streams along with
+    /// the Raft's committed index and a copy of the logs which were written as part of that update.
+    /// This optimizes replication speed for replication streams which are running at line rate.
+    ///
+    /// For the client path:
+    /// - Client's response channel can be persisted based on whether it needs Committed or
+    /// Applied state for messages.
+    /// - Every time the committed index is updated based on replication events, the BTreeMap storing
+    /// the channels will be checked for any keys which are <= new committed index. For anything which matches,
+    /// they will be removed and their response will be sent.
+    /// - As part of updating the committed index, after client responses have been sent, the logs
+    /// which need to be applied will be sent over to the storage engine to be applied.
+    /// - Once the committed logs have been applied to the state machine, the client requests which
+    /// are awaiting Applied state for their requests will be evaluated and responded to.
+    fn handle(&mut self, _msg: ClientRequest, _ctx: &mut Self::Context) -> Self::Result {
+        // TODO: implement this & finish up client request handling.
+        Box::new(fut::FutureResult::from(Ok(())))
+    }
 }
 
 // TODO:
 // ### admin commands
 // - get AdminCommands setup and implemented.
-//
-// ### clients
-// - create client message protobuf, used to generically wrap any type of client request.
-//   Put together docs on how applications should mitigate client retries which would
-//   lead to duplicates (request serial number tracking).
-// - implement handler for client requests.
 //
 // ### observability
 // - ensure that internal state transitions and updates are emitted for host application use. Such

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -3,16 +3,24 @@
 //! This module encapsulates the `ReplicationStream` actor which is used for maintaining a
 //! replication stream from a Raft leader node to a target follower node.
 
+
+use std::sync::Arc;
+
 use actix::prelude::*;
-use log::{error, warn};
+use log::{error, info, warn};
+use tokio::{
+    prelude::*,
+    fs::File,
+};
 
 use crate::{
+    config::{Config, SnapshotPolicy},
     proto,
-    raft::{
-        NodeId,
-        RaftRpcOut,
-    },
+    raft::{NodeId, Raft, RaftRpcOut},
+    storage::RaftStorage,
 };
+
+const MAILBOX_ERR_MESSAGE: &str = "Error communicating from ReplicationStream to Raft node.";
 
 /// An actor responsible for sending replication events to a target follower in the Raft cluster.
 ///
@@ -20,14 +28,48 @@ use crate::{
 /// is no longer the leader, it will drop the address of this actor which will cause this actor to
 /// stop.
 ///
-/// This actor is implemented in such a way that it will receive updates from the parent node as
+/// ### line rate replication
+/// This actor is implemented in such a way that it will receive updates from the Raft node as
 /// log entries are successfully appended to the log and flushed to disk. The Raft node will send
-/// the payload of log entries which were just appended along with the index immediately of the
-/// first entry, the index of the last entry, and the current commit index of the leader. With
-/// this information, replication streams can stay at line rate a majority of the time, and when
-/// follower is lagging behind, or is brand new to the cluster, the replication stream can bring
-/// the node up-to-speed, or even start the snapshot process for the follower.
-pub(crate) struct ReplicationStream {
+/// an `RSReplicate` payload of the log entries which were just appended to the log. With the
+/// information in the payload, replication streams can stay at line rate a majority of the time.
+///
+/// When running at line rate, replication requests will be buffered when there is an outstanding
+/// request, and all buffered entries will be sent over in the next request as one larger payload.
+///
+/// ### lagging replication
+/// When a replication request fails (typically due to target being new to the cluster, the target
+/// having been offline for some time, or any such reason), the replication stream will enter the
+/// `RSState::Lagging` state, indicating that the target needs to be brought up-to-speed and that
+/// it is no longer running at line rate. When such an event takes place, any buffered replication
+/// payload will be purged, and the replication stream will begin the process of bringing the
+/// target up-to-speed. The replication stream will notify the Raft node that it is no longer
+/// running at line rate, and the Raft node will stop sending entries in the `RSReplicate`
+/// messages until the target is caught up and ready to resume running at line rate.
+///
+/// #### bringing target up-to-date
+/// When the replication stream enters the `RSState::Lagging`, the replication stream will attempt
+/// to bring the target up-to-date based on the type of failure which triggered the state change.
+/// This Raft implementation uses a _conflict optimization_ algorithm as described in §5.3. As
+/// such, a `ConflictOpt` struct should always be present to help determine the last index to
+/// resume replication from.
+///
+/// If the node is far enough behind, based on the Raft's configuration, the target may need to be
+/// sent an InstallSnapshot RPC. When this needs to take place, the replication stream will
+/// transition to the state `RSState::InstallingSnapshot`, and will then proceed to stream a
+/// snapshot over to the target node.
+///
+/// #### back to line rate
+/// When the replication stream has finished with the snapshot process and/or has fetched a
+/// payload of entries to send to the target — before the payload is sent — the replication stream
+/// will transition back to state `RSState::LineRate`. This allows the replication stream to
+/// safely recover back to line rate even under heavy write load.
+///
+/// ----
+///
+/// NOTE: we do not stack replication requests to targets because this could result in
+/// out-of-order delivery.
+pub(crate) struct ReplicationStream<S: RaftStorage> {
     //////////////////////////////////////////////////////////////////////////
     // Static Fields /////////////////////////////////////////////////////////
 
@@ -41,23 +83,21 @@ pub(crate) struct ReplicationStream {
     /// will be brought down as part of a state transition to becoming a follower.
     term: u64,
     /// A channel for communicating with the Raft node which spawned this actor.
-    raftnode: Recipient<RSEvent>,
+    raftnode: Addr<Raft<S>>,
     /// The output channel used for sending RPCs to the transport/network layer.
     out: Recipient<RaftRpcOut>,
-    /// The rate at which heartbeats will be sent to followers to avoid election timeouts.
-    ///
-    /// This value is also used as a timeout. This ensures that requests don't get backed up due
-    /// to a logic error in the parent application's networking code.
-    heartbeat_rate: u64,
+    /// The Raft's runtime config.
+    config: Arc<Config>,
 
     //////////////////////////////////////////////////////////////////////////
     // Dynamic Fields ////////////////////////////////////////////////////////
 
+    /// The state of this replication stream, primarily corresponding to replication performance.
+    state: RSState,
     /// The index of the log entry to most recently be appended to the log by the leader.
     line_index: u64,
     /// The index of the highest log entry which is known to be committed in the cluster.
     line_commit: u64,
-
     /// The index of the next log to send.
     ///
     /// Each entry is initialized to leader's last log index + 1. Per the Raft protocol spec,
@@ -75,36 +115,51 @@ pub(crate) struct ReplicationStream {
     /// number of RPCs which need to be sent back and forth between a peer which is lagging
     /// behind. This is defined in §5.3.
     next_index: u64,
-
     /// An optional handle to the current outbound request to the target node.
     current_request: Option<SpawnHandle>,
+    /// An optional handle to the current heartbeat timeout operation.
+    ///
+    /// This does not represent the heartbeat request itself, it represents the timer which will
+    /// trigger a heartbeat in the future.
+    heartbeat: Option<SpawnHandle>,
+    /// An optional buffered payload of data to replicate to the target follower.
+    ///
+    /// The buffered payload here will be expanded as more replication commands come in from the
+    /// Raft node while there is a buffered instance here.
+    buffered_outbound_payload: Option<RSReplicate>,
 }
 
-impl ReplicationStream {
-    /// Send a heartbeat frame to the target node.
-    fn send_heartbeat(&mut self, ctx: Context<Self>) {
-        // Build the heartbeat frame to be sent to the follower.
-        let frame = RaftRpcOut{
-            target: self.target,
-            request: proto::RaftRequest::new_append(proto::AppendEntriesRequest{
-                term: self.term,
-                leader_id: self.id,
-                prev_log_index: self.line_index,
-                prev_log_term: self.term,
-                entries: Vec::with_capacity(0),
-                leader_commit: self.line_commit,
-            }),
-        };
+impl<S: RaftStorage> ReplicationStream<S> {
+    /// Drive the replication process forward.
+    ///
+    /// This method is usually called when a replication request is received or when a request to
+    /// the target node is finished. This will perform a check to see if there is a buffered
+    /// payload which needs to be sent to the target. If there is a buffered payload and no
+    /// outstanding request, then the payload will be sent immediately; else, replication will be
+    /// driven forward after the current request resolves.
+    fn drive_replication(&mut self, ctx: &mut Context<Self>) {
+        // If there is an outstanding request, or we are not runing at line rate, do nothing.
+        if self.current_request.is_some() || &self.state != &RSState::LineRate {
+            return;
+        }
 
-        let timeout = std::time::Duration::from_micros(self.heartbeat_rate);
-        let f = fut::wrap_future(self.out.send(frame))
-            .map_err(|err, act: &mut Self, _| error!("Actix messaging error while sending heartbeat to {}: {}", act.target, err))
-            .timeout(timeout, ())
-            .and_then(|res, _, _| fut::FutureResult::from(res))
-            .map(|res, act, ctx| act.handle_append_entries_response(ctx, res, None))
-            ;
+        // There is no outstanding request; if there is a buffered payload, send it, else return.
+        let buffered = match self.buffered_outbound_payload.take() {
+            None => return, // Nothing to do, so return.
+            Some(payload) => payload,
+        };
+        let payload = proto::AppendEntriesRequest{
+            term: self.term,
+            leader_id: self.id,
+            prev_log_index: self.line_index,
+            prev_log_term: self.term,
+            entries: buffered.entries,
+            leader_commit: self.line_commit,
+        };
+        self.send_payload(ctx, payload);
     }
 
+    /// Handle AppendEntries RPC responses from the target node.
     fn handle_append_entries_response(&mut self, ctx: &mut Context<Self>, res: proto::RaftResponse, payload_last_index: Option<u64>) {
         // Unpack the inner payload.
         let payload = match res.payload {
@@ -120,30 +175,249 @@ impl ReplicationStream {
             // If this was a proper replication event, notify Raft node.
             if let Some(idx) = payload_last_index {
                 self.next_index = idx + 1; // This should always be the next expected index.
-                let event = RSEvent::Replicated(RSEventReplicated{
+                let event = RSEvent::Replication(RSEventReplication{
                     target: self.target,
-                    stream_rate: if idx == self.line_index { RSRate::Line } else { RSRate::Lagging },
-                    last_log_index: idx,
+                    state: self.state.clone(),
+                    last_log_index: Some(idx),
                 });
                 ctx.spawn(fut::wrap_future(self.raftnode.send(event))
-                    .map_err(|err, act: &mut Self, _| error!("Error communicating from {} ReplicationStream to Raft node. {}", act.target, err)));
+                    .map_err(|err, act: &mut Self, _| error!("{} {} {}", MAILBOX_ERR_MESSAGE, act.target, err)));
             }
 
-            // Else, this was just a heartbeat. Nothing to do.
+            // Else, this was just a heartbeat. Do nothing.
             return;
         }
 
         // Replication was not successful, if a newer term has been returned, revert to follower.
-        if payload.term > self.term {
-            ctx.spawn(fut::wrap_future(self.raftnode.send(RSEvent::RevertToFollower))
-                .map_err(|err, act: &mut Self, _| error!("Error communicating from {} ReplicationStream to Raft node. {}", act.target, err)));
+        if &payload.term > &self.term {
+            ctx.spawn(fut::wrap_future(self.raftnode.send(RSEvent::RevertToFollower(self.target, payload.term)))
+                .map_err(|err, act: &mut Self, _| error!("{} {} {}", MAILBOX_ERR_MESSAGE, act.target, err)));
         }
 
-        // TODO: handle conflict opt. Even if no conflict opt has been presented, we still need to decrement `next_index`.
+        // Replication was not successful, handle conflict optimization record, else decrement `next_index`.
+        if let Some(conflict) = payload.conflict_opt {
+            // If the returned conflict opt index is greater than line index, then this is a
+            // logical error, and no action should be taken.
+            if &conflict.index > &self.line_index {
+                return;
+            }
+
+            // Check snapshot policy and handle conflict as needed.
+            match &self.config.snapshot_policy {
+                SnapshotPolicy::Disabled => {
+                    self.next_index = conflict.index;
+                    self.transition_to_lagging(ctx);
+                }
+                SnapshotPolicy::LogsSinceLast(threshold) => {
+                    let diff = &self.line_index - &conflict.index;
+                    if &diff >= threshold {
+                        // Follower is far behind and needs to receive an InstallSnapshot RPC.
+                        self.transition_to_installing_snapshot(ctx);
+                    } else {
+                        // Follower is behind, but not too far behind to receive an InstallSnapshot RPC.
+                        self.next_index = conflict.index;
+                        self.transition_to_lagging(ctx);
+                    }
+                }
+            }
+        } else {
+            self.next_index -= 1;
+            self.transition_to_lagging(ctx);
+        }
+    }
+
+    /// Handle a request to replicate the given payload of entries.
+    ///
+    /// If there is already an outbound request, this payload will be buffered. If there is
+    /// already a buffered payload, the payloads will be combined. This helps to keep throughput
+    /// as high as possible when dealing with high write load conditions.
+    fn handle_rsreplicate_message(&mut self, ctx: &mut Context<Self>, mut msg: RSReplicate) {
+        // Always update line commit & index info first so that this value can be used in all AppendEntries RPCs.
+        self.line_commit = msg.line_commit;
+        self.line_index = msg.line_index;
+
+        // If there is a buffered replication payload, update it and finish this up.
+        if let Some(payload) = &mut self.buffered_outbound_payload {
+            payload.line_commit = msg.line_commit;
+            payload.line_index = msg.line_index;
+            payload.entries.append(&mut msg.entries);
+        } else {
+            self.buffered_outbound_payload = Some(msg);
+        }
+
+        self.drive_replication(ctx);
+    }
+
+    /// Send a heartbeat frame to the target node.
+    fn send_heartbeat(&mut self, ctx: &mut Context<Self>) {
+        // Don't do anything if there is already a request sent to the target.
+        if self.current_request.is_some() {
+            return;
+        }
+
+        // Prioritize sending entries if we have a buffered payload.
+        if self.buffered_outbound_payload.is_some() {
+            self.drive_replication(ctx);
+            return;
+        }
+
+        // Build the heartbeat frame to be sent to the follower.
+        let payload = proto::AppendEntriesRequest{
+            term: self.term,
+            leader_id: self.id,
+            prev_log_index: self.line_index,
+            prev_log_term: self.term,
+            entries: Vec::with_capacity(0),
+            leader_commit: self.line_commit,
+        };
+        self.send_payload(ctx, payload);
+    }
+
+    /// Unconditionally send the given payload to the target.
+    ///
+    /// This will spawn a new future for the operation of sending the payload to the target peer.
+    /// The spawn handle from that future will be bound to `current_request`. The request will
+    /// timeout after `heartbeat_rate`.
+    ///
+    /// After the request resolves, the spawn handle in `current_request` will be dropped (not
+    /// cancelled), `update_heartbeat` will be called, and `drive_replication` will be called to
+    /// ensure that any buffered payload ready to be sent will immediately be sent.
+    fn send_payload(&mut self, ctx: &mut Context<Self>, request: proto::AppendEntriesRequest) {
+        let payload_last_index = request.entries.last().map(|val| val.index);
+        let payload = RaftRpcOut{
+            target: self.target,
+            request: proto::RaftRequest::new_append(request),
+        };
+
+        // Send the payload.
+        let timeout = std::time::Duration::from_millis(self.config.heartbeat_interval);
+        let handle = ctx.spawn(fut::wrap_future(self.out.send(payload))
+            // Setup timeout.
+            .timeout(timeout, MailboxError::Timeout)
+            // Handle initial error conditions.
+            .map_err(|err, act: &mut Self, _| match err {
+                MailboxError::Closed => error!("Error while sending replication frames to {}. {:?}", act.target, err),
+                MailboxError::Timeout => warn!("Replication request to node {} timedout. Timeout config {:?}ms. {:?}", act.id, act.config.heartbeat_interval, err),
+            })
+            // Flatten inner result.
+            .and_then(|res, _, _| fut::FutureResult::from(res))
+            // Process the response.
+            .map(move |res, act, ctx| act.handle_append_entries_response(ctx, res, payload_last_index))
+            // Remove the retained spawn handle, update heartbeat & drive the replication process forward.
+            .then(|res, act, ctx| {
+                act.current_request.take();
+                act.update_heartbeat(ctx);
+                act.drive_replication(ctx);
+                fut::FutureResult::from(res)
+            }));
+        self.current_request = Some(handle);
+    }
+
+    /// Send the specified snapshot over to the target node.
+    fn send_snapshot(&mut self, _: &mut Context<Self>, snap: InstallSnapshotResponse) -> impl ActorFuture<Actor=Self, Item=(), Error=()> {
+        // Ensure state is still `RSState::InstallingSnapshot`.
+        if &self.state != &RSState::InstallingSnapshot {
+            return fut::Either::A(fut::FutureResult::from(Ok(())));
+        }
+
+        // Look up the snapshot on disk.
+        fut::Either::B(fut::wrap_future(tokio::fs::File::open(snap.pointer.path.clone()))
+            .map_err(|err, _, _| error!("Error opening snapshot file. {}", err))
+            // We've got a successful file handle, start streaming the chunks over to the target.
+            .and_then(move |file, act: &mut Self, _| {
+                // Create a snapshot stream from the file and stream it over to the target.
+                let snap_stream = SnapshotStream::new(file, act.config.snapshot_max_chunk_size as usize, act.term, act.id, snap.index, snap.term);
+                fut::wrap_stream(snap_stream)
+                    .map_err(|err, act: &mut Self, _| error!("Error while streaming snapshot to target {}: {}", &act.target, err))
+                    .and_then(|rpc, act: &mut Self, _| {
+                        // Send snapshot RPC frame over to target.
+                        fut::wrap_future(act.out.send(RaftRpcOut{
+                            target: act.target,
+                            request: proto::RaftRequest{payload: Some(proto::raft_request::Payload::InstallSnapshot(rpc))},
+                        }))
+                        .map_err(|err, _: &mut Self, _| error!("Error while sending outbound InstallSnapshot RPC: {}", err))
+                        .and_then(|res, _, _| fut::FutureResult::from(res))
+                        // Handle response from target.
+                        .and_then(|res, act, ctx| act.handle_install_snapshot_response(ctx, res))
+                    })
+                    .finish()
+            })
+            // If we've run into an error during the above process, we restart the process.
+            .map_err(|_, act, ctx| act.transition_to_installing_snapshot(ctx)))
+    }
+
+    /// Handle frames from the target node which are in response to an InstallSnapshot RPC request.
+    fn handle_install_snapshot_response(&mut self, _: &mut Context<Self>, res: proto::RaftResponse) -> impl ActorFuture<Actor=Self, Item=(), Error=()> {
+        // Unpack inner payload.
+        use proto::raft_response::Payload;
+        match res.payload {
+            // Check the response term. As long as everything still matches, then we are good to resume.
+            Some(Payload::InstallSnapshot(inner)) => if &inner.term == &self.term {
+                fut::FutureResult::from(Ok(()))
+            } else {
+                info!("Response from InstallSnapshot RPC sent to {} indicates a newer term {} is in session, reverting to follower.", &self.target, &inner.term);
+                self.raftnode.do_send(RSEvent::RevertToFollower(self.target, inner.term));
+                fut::FutureResult::from(Err(()))
+            },
+            _ => {
+                warn!("Unexpected RPC response type from {} after sending InstallSnapshot RPC.", self.target);
+                fut::FutureResult::from(Err(()))
+            }
+        }
+    }
+
+    /// Transition this actor to the state `RSState::Lagging` & notify Raft node.
+    fn transition_to_lagging(&mut self, ctx: &mut Context<Self>) {
+        self.state = RSState::Lagging;
+        self.buffered_outbound_payload.take(); // Remove any buffered payload.
+        let event = RSEventReplication{target: self.target, state: self.state.clone(), last_log_index: None};
+        ctx.spawn(fut::wrap_future(self.raftnode.send(RSEvent::Replication(event)))
+            .map_err(|err, act: &mut Self, _| error!("{} {} {}", MAILBOX_ERR_MESSAGE, act.target, err)));
+
+        // TODO: RESUME HERE IMMEDIATE <<<<<<<<
+    }
+
+    /// Transition this actor to the state `RSState::InstallingSnapshot` & notify Raft node.
+    fn transition_to_installing_snapshot(&mut self, ctx: &mut Context<Self>) {
+        self.state = RSState::InstallingSnapshot;
+        self.buffered_outbound_payload.take(); // Remove any buffered payload.
+        let event = InstallSnapshot{target: self.target};
+        let f = fut::wrap_future(self.raftnode.send(event))
+            // Log actix messaging errors.
+            .map_err(|err, act: &mut Self, _| error!("{} {} {}", MAILBOX_ERR_MESSAGE, act.target, err))
+            // Flatten inner result.
+            .and_then(|res, _, _| fut::FutureResult::from(res))
+            // Handle response from Raft node and start streaming over the snapshot.
+            .and_then(|res, act, ctx| act.send_snapshot(ctx, res))
+            // If an error has come up, and we are still in snapshot state, simply retry the operation.
+            .map_err(|_, act, ctx| {
+                if &act.state == &RSState::InstallingSnapshot {
+                    act.transition_to_installing_snapshot(ctx);
+                }
+            });
+        ctx.spawn(f);
+    }
+
+    /// Update the heartbeat mechanism.
+    ///
+    /// When called, this method will cancel any pending heartbeat and will schedule a new one
+    /// based on the configured `heartbeat_rate`. Once a request is successfully returned from the
+    /// target, this method should be called to ensure a timeout isn't hit, and also to ensure
+    /// this system is not sending more network requests than is needed.
+    fn update_heartbeat(&mut self, ctx: &mut Context<Self>) {
+        // Remove pending heartbeat if present.
+        if let Some(hb) = self.heartbeat.take() {
+            ctx.cancel_future(hb);
+        }
+
+        // Setup a new heartbeat to be sent after the `heartbeat_rate` duration.
+        let later = std::time::Duration::from_millis(self.config.heartbeat_interval);
+        let handle = ctx.run_later(later, |act, ctx| act.send_heartbeat(ctx));
+        self.heartbeat = Some(handle);
     }
 }
 
-impl Actor for ReplicationStream {
+impl<S: RaftStorage> Actor for ReplicationStream<S> {
     type Context = Context<Self>;
 
     /// Perform actors startup routine.
@@ -151,10 +425,9 @@ impl Actor for ReplicationStream {
     /// As part of startup, the replication stream must send an empty AppendEntries RPC payload
     /// to its target to ensure that the target node is aware of the leadership state of this
     /// Raft node.
-    fn started(&mut self, _: &mut Self::Context) {
+    fn started(&mut self, ctx: &mut Self::Context) {
         // Send initial heartbeat.
-
-        // Start individual heartbeat for this target.
+        self.send_heartbeat(ctx);
     }
 }
 
@@ -162,14 +435,34 @@ impl Actor for ReplicationStream {
 // RSReplicate ///////////////////////////////////////////////////////////////////////////////////
 
 /// A replication stream message indicating a new payload of entries to be replicated.
-#[derive(Clone, Message)]
+#[derive(Clone)]
 pub(crate) struct RSReplicate {
     /// The payload of entries to be replicated.
+    ///
+    /// The payload will only be empty if the Raft node detects that this replication stream is
+    /// not running at line rate, as buffering too many entries could cause memory issues.
     entries: Vec<proto::Entry>,
     /// The index of the log entry to most recently be appended to the log by the leader.
+    ///
+    /// This will always be the index of the last element in the entries payload if values are
+    /// given in the payload.
     line_index: u64,
     /// The index of the highest log entry which is known to be committed in the cluster.
     line_commit: u64,
+}
+
+impl Message for RSReplicate {
+    type Result = Result<(), ()>;
+}
+
+impl<S: RaftStorage> Handler<RSReplicate> for ReplicationStream<S> {
+    type Result = Result<(), ()>;
+
+    /// Handle replication requests from the Raft node.
+    fn handle(&mut self, msg: RSReplicate, ctx: &mut Self::Context) -> Self::Result {
+        self.handle_rsreplicate_message(ctx, msg);
+        Ok(())
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -178,25 +471,125 @@ pub(crate) struct RSReplicate {
 /// A replication stream message indicating an event coming from a replication stream.
 #[derive(Message)]
 pub(crate) enum RSEvent {
-    /// An event indicating a successful replication event on a target node.
-    Replicated(RSEventReplicated),
+    /// An event representing some replication stream update.
+    Replication(RSEventReplication),
     /// A newer term was observed in a response from a replication request, become a follower.
-    RevertToFollower,
+    ///
+    /// This variant simply wraps the ID of the node from which the newer term was observed along
+    /// with the value of the new term.
+    RevertToFollower(NodeId, u64),
 }
 
-pub(crate) struct RSEventReplicated {
+/// An event representing some replication stream update.
+pub(crate) struct RSEventReplication {
     /// The ID of the Raft node which this RSEvent relates to.
     target: NodeId,
-    /// The rate of the replication stream.
-    stream_rate: RSRate,
+    /// The state of the replication stream.
+    state: RSState,
     /// The index of the last log which was successfully replicated as part of this event.
-    last_log_index: u64,
+    ///
+    /// This value may be `None` due to some state changes related to conflicts or snapshots. If
+    /// this value is `None`, then the information here is indicative of the replication stream
+    /// transitioning to the specified state.
+    last_log_index: Option<u64>,
 }
 
 /// The rate of a replication stream.
-pub(crate) enum RSRate {
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) enum RSState {
     /// The replication stream is running at line rate.
-    Line,
-    /// The replication stream is lagging behind due to follower state.
+    LineRate,
+    /// The replication stream is lagging behind due to the target node.
     Lagging,
+    /// The replication stream is streaming a snapshot over to the target node.
+    InstallingSnapshot,
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// InstallSnapshot ///////////////////////////////////////////////////////////////////////////////
+
+/// An event from a replication stream requesting a snapshot to be installed on the target.
+pub(crate) struct InstallSnapshot {
+    /// The ID of the Raft node which this RSEvent relates to.
+    target: NodeId,
+}
+
+impl Message for InstallSnapshot {
+    type Result = Result<InstallSnapshotResponse, ()>;
+}
+
+/// A resonse from the Raft node for requesting to install a snapshot on a target.
+pub(crate) struct InstallSnapshotResponse {
+    pub index: u64,
+    pub term: u64,
+    pub pointer: proto::EntrySnapshotPointer,
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// SnapshotStream ////////////////////////////////////////////////////////////////////////////////
+
+/// An async stream of the chunks of a given file.
+struct SnapshotStream {
+    file: File,
+    offset: u64,
+    buffer: Vec<u8>,
+    term: u64,
+    leader_id: NodeId,
+    last_included_index: u64,
+    last_included_term: u64,
+    has_sent_terminal_frame: bool,
+}
+
+impl SnapshotStream {
+    /// Create a new instance.
+    pub fn new(file: File, bufsize: usize, term: u64, leader_id: NodeId, last_included_index: u64, last_included_term: u64) -> Self {
+        Self{
+            file, offset: 0, buffer: Vec::with_capacity(bufsize),
+            term, leader_id, last_included_index, last_included_term,
+            has_sent_terminal_frame: false,
+        }
+    }
+}
+
+impl futures::Stream for SnapshotStream {
+    type Item = proto::InstallSnapshotRequest;
+    type Error = tokio::io::Error;
+
+    fn poll(&mut self) -> futures::Poll<Option<Self::Item>, Self::Error> {
+        self.file.read_buf(&mut self.buffer).map(move |pollres| match pollres {
+            Async::NotReady => Async::NotReady,
+            Async::Ready(bytes_read) => {
+                // The stream is ready to yield the next item.
+                if bytes_read > 0 {
+                    self.offset += bytes_read as u64;
+                    let data = self.buffer.split_off(0); // Allocates a new buf only when we have successfully read bytes.
+                    let frame = proto::InstallSnapshotRequest{
+                        term: self.term, leader_id: self.leader_id,
+                        last_included_index: self.last_included_index,
+                        last_included_term: self.last_included_term,
+                        offset: self.offset, data, done: false,
+                    };
+                    Async::Ready(Some(frame))
+                }
+
+                // There are no bytes left in the file, but we need to send the terminal RPC frame,
+                // so mark the stream as being complete and send the terminal frame.
+                else if !self.has_sent_terminal_frame {
+                    self.has_sent_terminal_frame = true;
+                    let frame = proto::InstallSnapshotRequest{
+                        term: self.term, leader_id: self.leader_id,
+                        last_included_index: self.last_included_index,
+                        last_included_term: self.last_included_term,
+                        offset: self.offset, data: Vec::with_capacity(0), done: true,
+                    };
+                    Async::Ready(Some(frame))
+                }
+
+                // There are no bytes left in the file, and we've already sent the terminal frame. We're done.
+                else {
+                    Async::Ready(None)
+                }
+            }
+        })
+    }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -126,9 +126,9 @@ impl Message for AppendLogEntries {
 pub struct CreateSnapshot {
     /// The new snapshot should start from entry `0` and should cover all entries through the
     /// index specified here, inclusive.
-    through: u64,
+    pub through: u64,
     /// The directory where the new snapshot is to be written.
-    snapshot_dir: String,
+    pub snapshot_dir: String,
 }
 
 impl Message for CreateSnapshot {
@@ -146,8 +146,8 @@ impl Message for CreateSnapshot {
 /// ### implementation algorithm
 /// - Upon receiving the request, a new snapshot file should be created on disk.
 /// - Every new chunk of data received should be written to the new snapshot file starting at the
-/// `offset` specified in the chunk. Due to transient communications issues, chunks may be
-/// redelivered.
+/// `offset` specified in the chunk. The Raft actor will ensure that redelivered chunks are not
+/// sent through multiple times.
 /// - If the receiver is dropped, the snapshot which was being created should be removed from
 /// disk.
 ///
@@ -163,13 +163,13 @@ impl Message for CreateSnapshot {
 /// recreated from the new snapshot. Return once the state machine has been brought up-to-date.
 pub struct InstallSnapshot {
     /// The term which the final entry of this snapshot covers.
-    term: u64,
+    pub term: u64,
     /// The index of the final entry which this snapshot covers.
-    index: u64,
+    pub index: u64,
     /// The directory where the new snapshot is to be written.
-    snapshot_dir: String,
+    pub snapshot_dir: String,
     /// A stream of data chunks for this snapshot.
-    stream: UnboundedReceiver<InstallSnapshotChunk>,
+    pub stream: UnboundedReceiver<InstallSnapshotChunk>,
 }
 
 impl Message for InstallSnapshot {
@@ -179,11 +179,11 @@ impl Message for InstallSnapshot {
 /// A chunk of snapshot data.
 pub struct InstallSnapshotChunk {
     /// The byte offset where chunk is positioned in the snapshot file.
-    offset: u64,
+    pub offset: u64,
     /// The raw bytes of the snapshot chunk, starting at `offset`.
-    data: Vec<u8>,
+    pub data: Vec<u8>,
     /// Will be `true` if this is the last chunk in the snapshot.
-    done: bool,
+    pub done: bool,
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -202,7 +202,7 @@ pub struct InstallSnapshotChunk {
 /// If there is no active snapshot file, then `None` should be returned.
 pub struct GetCurrentSnapshot {
     /// The directory where the system has been configured to store snapshots.
-    snapshot_dir: String,
+    pub snapshot_dir: String,
 }
 
 impl Message for GetCurrentSnapshot {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -210,7 +210,7 @@ impl Message for GetCurrentSnapshot {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
-// GetCurrentSnapshot ////////////////////////////////////////////////////////////////////////////
+// ApplyEntriesToStateMachine ////////////////////////////////////////////////////////////////////
 
 /// A request from the Raft node to apply the given log entries to the state machine.
 ///
@@ -282,11 +282,11 @@ pub trait RaftStorage
     where
         Self: Actor<Context=Context<Self>>,
         Self: Handler<GetInitialState> + ToEnvelope<Self, GetInitialState>,
+        Self: Handler<SaveHardState> + ToEnvelope<Self, SaveHardState>,
         Self: Handler<GetLogEntries> + ToEnvelope<Self, GetLogEntries>,
         Self: Handler<AppendLogEntries> + ToEnvelope<Self, AppendLogEntries>,
         Self: Handler<ApplyEntriesToStateMachine> + ToEnvelope<Self, ApplyEntriesToStateMachine>,
         Self: Handler<CreateSnapshot> + ToEnvelope<Self, CreateSnapshot>,
         Self: Handler<InstallSnapshot> + ToEnvelope<Self, InstallSnapshot>,
         Self: Handler<GetCurrentSnapshot> + ToEnvelope<Self, GetCurrentSnapshot>,
-        Self: Handler<SaveHardState> + ToEnvelope<Self, SaveHardState>,
 {}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -119,8 +119,9 @@ impl Message for AppendLogEntries {
 /// old snapshot first, and resume processing from its last entry.
 /// - The newly generated snapshot should be written to the directory specified by `snapshot_dir`.
 /// - All previous entries in the log should be deleted up to the entry specified at index
-/// `through`. The entry at index `through` should be replaced with a new entry created from
-/// calling `actix_raft::proto::Entry::new_snapshot_pointer(...)`.
+/// `through`.
+/// - The entry at index `through` should be replaced with a new entry created from calling
+/// `actix_raft::proto::Entry::new_snapshot_pointer(...)`.
 /// - Any old snapshot will no longer have representation in the log, and should be deleted.
 /// - Return a copy of the snapshot pointer entry created earlier.
 pub struct CreateSnapshot {
@@ -268,9 +269,10 @@ impl Message for SaveHardState {
 /// `Config` value. The Raft node will send a message to this `RaftStorage` interface when a
 /// periodic snapshot is to be generated based on its configuration.
 ///
-/// Log compaction, which is what taking a snapshot is for, is an application specific process.
-/// The essential idea is that superfluous records in the log will be removed. See §7 for more
-/// details. There are a few snapshot related messages which the `RaftStorage` actor must handle.
+/// Log compaction, which is part of what taking a snapshot is for, is an application specific
+/// process. The essential idea is that superfluous records in the log will be removed. See §7 for
+/// more details. There are a few snapshot related messages which the `RaftStorage` actor must
+/// handle:
 ///
 /// - `CreateSnapshot`: a request to create a new snapshot of the current log.
 /// - `InstallSnapshot`: the Raft leader is streaming over a snapshot, install it.


### PR DESCRIPTION
Added config options max_payload_entries & snapshot_max_chunk_size for
controlling the data replication process.

Added SnapshotStream type for being able to deal with a snapshot file as
a stream of chunks. Streaming snapshot chunks over to a target follower
is now complete. Implementing the handler for these RPCs on the
receiving end is still outstanding.

### todo
NOTE: `ReplicationStream` actor has been fully audited, and is ready to rock.
- [x] update Raft actor to handle the various messages coming from the replication stream actors.
- [x] perform full audit of Raft actor & open next tasks as needed. This is very close to being finished, then it will be on to testing.
- [x] finish implementing the leadership protocol in the Raft actor.
- [x] spawn replication stream actors as part of transition into Raft leadership mode.
- [x] get work squared away for handling client requests. 
- [x] perform a full audit of storage & replication stream docs, to ensure everything is still accurate and up-to-date.
- [x] open issue for updating docs on API and usage. 
