### PR TITLE
Fix a bug with single-node init routine.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 changelog
 =========
 ### 0.4
+#### 0.4.1
+A few bug fixes.
+
+- Fixed an issue where a node in a single-node Raft was not resuming as leader after a crash.
+- Fixed an issue where hard state was not being saved after a node becomes leader in a single-node Raft.
+- Fixed an issue where the client request pipeline (a `Stream` with the `actix::StreamFinish`) was being closed after an error was returned during processing of client requests (which should not cause the stream to close). This was unexpected and undocumented behavior, very simple fix though.
+
 #### 0.4.0
 This changeset introduces a new `AppDataResponse` type which represents a concrete data type which must be sent back from the `RaftStorage` impl from the `ApplyEntryToStateMachine` handler. This provides a more direct path for returning application level data from the storage impl. Often times this is needed for responding to client requests in a timely / efficient manner.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-raft"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["Anthony Dodd <Dodd.AnthonyJosiah@gmail.com>"]
 categories = ["algorithms", "asynchronous", "data-structures"]

--- a/src/raft/admin.rs
+++ b/src/raft/admin.rs
@@ -60,6 +60,7 @@ impl<D: AppData, R: AppDataResponse, E: AppError, N: RaftNetwork<D>, S: RaftStor
             self.current_term += 1;
             self.voted_for = Some(self.id);
             self.become_leader(ctx);
+            self.save_hard_state(ctx);
         } else {
             self.become_candidate(ctx);
         }

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -301,6 +301,7 @@ impl<D: AppData, R: AppDataResponse, E: AppError, N: RaftNetwork<D>, S: RaftStor
         // Spawn stream which consumes client RPCs.
         ctx.spawn(fut::wrap_stream(client_request_receiver)
             .and_then(|msg, act: &mut Self, ctx| act.process_client_rpc(ctx, msg))
+            .then(|_, _, _| fut::ok(())) // Ensure errors don't cause the stream to close.
             .finish());
 
         // Spawn new replication stream actors.


### PR DESCRIPTION
If a single-node Raft was making progress and crashed, the init routine
was not taking into account needing to re-enter leader state.

Closes #29 