### PR TITLE
A set of changes for a 0.4.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 changelog
 =========
 ### 0.4
+#### 0.4.2
+A few QOL improvements.
+
+- Fixed an issue where the value for `current_leader` was not being set to `None` when becoming a candidate. This isn't really a *bug* per se, as no functionality depended on this value as far as Raft is concerned, but it is an issue that impacts the metrics system. This value is now being updated properly.
+- Made the `messages::ClientPayload::new_base` constructor `pub(crate)` instead of `pub`, which is what the intention was originally, but I was apparently tired `:)`.
+- Implemented [#25](https://github.com/railgun-rs/actix-raft/issues/25). Implementing Display+Error for the admin error types.
+
 #### 0.4.1
 A few bug fixes.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-raft"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 authors = ["Anthony Dodd <Dodd.AnthonyJosiah@gmail.com>"]
 categories = ["algorithms", "asynchronous", "data-structures"]

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -36,6 +36,17 @@ pub enum InitWithConfigError {
     NotAllowed,
 }
 
+impl std::fmt::Display for InitWithConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InitWithConfigError::Internal => write!(f, "An error internal to Raft has taken place."),
+            InitWithConfigError::NotAllowed => write!(f, "Submission of this command to this node is not allowed due to the state of the node."),
+        }
+    }
+}
+
+impl std::error::Error for InitWithConfigError {}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // ProposeConfigChange ///////////////////////////////////////////////////////////////////////////
 
@@ -100,3 +111,17 @@ pub enum ProposeConfigChangeError<D: AppData, R: AppDataResponse, E: AppError> {
     /// removed have already been scheduled for removal and/or do not exist in the current config.
     Noop,
 }
+
+impl<D: AppData, R: AppDataResponse, E: AppError> std::fmt::Display for ProposeConfigChangeError<D, R, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProposeConfigChangeError::ClientError(err) => write!(f, "{}", err),
+            ProposeConfigChangeError::InoperableConfig => write!(f, "The given config would leave the cluster in an inoperable state."),
+            ProposeConfigChangeError::Internal => write!(f, "An error internal to Raft has taken place."),
+            ProposeConfigChangeError::NodeNotLeader(leader_opt) => write!(f, "The handling node is not the Raft leader. Tracked value for cluster leader: {:?}", leader_opt),
+            ProposeConfigChangeError::Noop => write!(f, "The proposed config change would have no effect, this is a no-op."),
+        }
+    }
+}
+
+impl<D: AppData, R: AppDataResponse, E: AppError> std::error::Error for ProposeConfigChangeError<D, R, E> {}

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -327,7 +327,7 @@ impl<D: AppData, R: AppDataResponse, E: AppError> ClientPayload<D, R, E> {
     }
 
     /// Create a new instance.
-    pub fn new_base(entry: EntryPayload<D>, response_mode: ResponseMode) -> Self {
+    pub(crate) fn new_base(entry: EntryPayload<D>, response_mode: ResponseMode) -> Self {
         Self{entry, response_mode, marker0: std::marker::PhantomData, marker1: std::marker::PhantomData}
     }
 

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -251,6 +251,7 @@ impl<D: AppData, R: AppDataResponse, E: AppError, N: RaftNetwork<D>, S: RaftStor
         // Setup new term.
         self.current_term += 1;
         self.voted_for = Some(self.id);
+        self.current_leader = None;
         self.save_hard_state(ctx);
 
         // Send RPCs to all members in parallel.


### PR DESCRIPTION
Fixed an issue where the value for `current_leader` was not being set
to `None` when becoming a candidate. This isn't really a *bug* per se,
as no functionality depended on this value as far as Raft is concerned,
but it is an issue that impacts the metrics system. This value is now
being updated properly.

Made the `messages::ClientPayload::new_base` constructor `pub(crate)`
instead of `pub`, which is what the intention was originally, but I
was apparently tired `:)`.

Implemented [#25](https://github.com/railgun-rs/actix-raft/issues/25).
Implementing Display+Error for the admin error types.

Closes #25 