### PR TITLE
Bug empty entries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           command: test
           args: -p async-raft --test initialization
+      - name: Integration Test | metrics state machine consistency
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p async-raft --test metrics_state_machine_consistency
       - name: Integration Test | NonVoter restart
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog follows the patterns described here: https://keepachangelog.com/e
 
 ## [unreleased]
 
+### fixed
+
+- Fixed [117](https://github.com/async-raft/async-raft/pull/117) `last_applied` should be updated only when logs actually applied.
+
 ## async-raft 0.6.1
 ### fixed
 - Fixed [#105](https://github.com/async-raft/async-raft/issues/105) where function `set_target_state` missing `else` condition.

--- a/async-raft/tests/bug_empty_entries.rs
+++ b/async-raft/tests/bug_empty_entries.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+use std::time::Duration;
+use std::collections::HashSet;
+
+use anyhow::Result;
+use maplit::hashset;
+
+use async_raft::Config;
+use fixtures::RaftRouter;
+
+mod fixtures;
+
+/// Cluster bug_empty_entries test.
+///
+///
+///
+/// What does this test do?
+///
+/// - brings a one node cluster online.
+/// - write a log.
+/// - brings a non-voter, setup replication
+/// - it shows that the log will never be replicated to the non-voter.
+///
+/// RUST_LOG=async_raft,memstore,bug_empty_entries=trace cargo test -p async-raft --test bug_empty_entries
+#[tokio::test(flavor = "multi_thread", worker_threads = 6)]
+async fn bug_empty_entries() -> Result<()> {
+    fixtures::init_tracing();
+
+    // Setup test dependencies.
+    let config = Arc::new(Config::build("test".into()).validate().expect("failed to build Raft config"));
+    let router = Arc::new(RaftRouter::new(config.clone()));
+
+    router.new_raft_node(0).await;
+
+    let mut want;
+
+    tracing::info!("--- initializing cluster of 1 node");
+    router.initialize_from_single_node(0).await?;
+    want = 1;
+    wait_log(router.clone(), &hashset![0], want).await?;
+
+
+    tracing::info!("--- write one log");
+    router.client_request_many(0, "client", 1).await;
+    want += 1;
+    wait_log(router.clone(), &hashset![0], want).await?;
+
+
+    tracing::info!("--- adding 1 non-voter nodes");
+    router.new_raft_node(1).await;
+    router.add_non_voter(0, 1).await?;
+    wait_log(router.clone(), &hashset![0, 1], want).await?;
+
+    Ok(())
+}
+
+async fn wait_log(router: std::sync::Arc<fixtures::RaftRouter>, node_ids: &HashSet<u64>, want_log: u64) -> anyhow::Result<()> {
+    let timeout = Duration::from_millis(500);
+    for i in node_ids.iter() {
+        router.wait_for_metrics(&i, |x| { x.last_log_index == want_log }, timeout, &format!("n{}.last_log_index -> {}", i, want_log)).await?;
+        router.wait_for_metrics(&i, |x| { x.last_applied == want_log }, timeout, &format!("n{}.last_applied -> {}", i, want_log)).await?;
+    }
+    Ok(())
+}

--- a/async-raft/tests/fixtures/mod.rs
+++ b/async-raft/tests/fixtures/mod.rs
@@ -5,7 +5,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Result, Context};
 use tokio::sync::RwLock;
 use tracing_subscriber::prelude::*;
 
@@ -121,7 +121,7 @@ impl RaftRouter {
         let rt = self.routing_table.read().await;
         let addr = rt
             .get(node_id)
-            .ok_or_else(|| anyhow::anyhow!("could not find node {} in routing table", node_id))?;
+            .with_context(|| format!("could not find node {} in routing table", node_id))?;
         let sto = addr.clone().1;
         Ok(sto)
     }
@@ -133,7 +133,7 @@ impl RaftRouter {
         T: Fn(&RaftMetrics) -> bool,
     {
         let rt = self.routing_table.read().await;
-        let node = rt.get(node_id).ok_or_else(|| anyhow::anyhow!("node {} not found", node_id))?;
+        let node = rt.get(node_id).with_context(|| format!("node {} not found", node_id))?;
         let mut mrx = node.0.metrics().clone();
 
         loop {

--- a/async-raft/tests/metrics_state_machine_consistency.rs
+++ b/async-raft/tests/metrics_state_machine_consistency.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::hashset;
+
+use async_raft::{Config, State};
+use fixtures::RaftRouter;
+
+mod fixtures;
+
+/// Cluster metrics_state_machine_consistency test.
+///
+/// What does this test do?
+///
+/// - brings 2 nodes online: one leader and one non-voter.
+/// - write one log to the leader.
+/// - asserts that when metrics.last_applied is upto date, the state machine should be upto date too.
+///
+/// RUST_LOG=async_raft,memstore,metrics_state_machine_consistency=trace cargo test -p async-raft --test metrics_state_machine_consistency
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_state_machine_consistency() -> Result<()> {
+    fixtures::init_tracing();
+
+    // Setup test dependencies.
+    let config = Arc::new(Config::build("test".into()).validate().expect("failed to build Raft config"));
+    let router = Arc::new(RaftRouter::new(config.clone()));
+
+    router.new_raft_node(0).await;
+    router.new_raft_node(1).await;
+
+    tracing::info!("--- initializing single node cluster");
+
+    // Wait for node 0 to become leader.
+    router.initialize_with(0, hashset![0]).await?;
+    router
+        .wait_for_metrics(
+            &0u64,
+            |x| x.state == State::Leader,
+            Duration::from_micros(100),
+            "n0.state -> Leader",
+        )
+        .await;
+
+    tracing::info!("--- add one non-voter");
+    router.add_non_voter(0, 1).await?;
+
+    tracing::info!("--- write one log");
+    router.client_request(0, "foo", 1).await;
+
+    // Wait for metrics to be up to date.
+    // Once last_applied updated, the key should be visible in state machine.
+    tracing::info!("--- wait for log to sync");
+    let want = 2u64;
+    for node_id in 0..2 {
+        router
+            .wait_for_metrics(
+                &node_id,
+                |x| x.last_applied == want,
+                Duration::from_micros(100),
+                &format!("n{}.last_applied -> {}", node_id, want),
+                )
+            .await;
+
+        let sto = router.get_sto(&node_id).await;
+        assert!(sto.get_state_machine().await.client_status.get("foo").is_some());
+
+    }
+
+    Ok(())
+}

--- a/async-raft/tests/metrics_state_machine_consistency.rs
+++ b/async-raft/tests/metrics_state_machine_consistency.rs
@@ -40,7 +40,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
             Duration::from_micros(100),
             "n0.state -> Leader",
         )
-        .await;
+        .await?;
 
     tracing::info!("--- add one non-voter");
     router.add_non_voter(0, 1).await?;
@@ -60,7 +60,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
                 Duration::from_micros(100),
                 &format!("n{}.last_applied -> {}", node_id, want),
                 )
-            .await;
+            .await?;
 
         let sto = router.get_storage_handle(&node_id).await?;
         assert!(sto.get_state_machine().await.client_status.get("foo").is_some());

--- a/async-raft/tests/metrics_state_machine_consistency.rs
+++ b/async-raft/tests/metrics_state_machine_consistency.rs
@@ -62,7 +62,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
                 )
             .await;
 
-        let sto = router.get_sto(&node_id).await;
+        let sto = router.get_storage_handle(&node_id).await?;
         assert!(sto.get_state_machine().await.client_status.get("foo").is_some());
 
     }


### PR DESCRIPTION
`cargo test -p async-raft --test bug_empty_entries`

You see a timeout waiting for log to replicate to NonVoter:

`Error: timeout wait for n1.last_log_index -> 2 latest metrics: RaftMetrics { id: 1, state: NonVoter, current_term: 1, last_log_index: 0, last_applied: 0, current_leader: Some(0), membership_config: MembershipConfig { members: {1}, members_after_consensus: None } }`

To reproduce the bug described in #122 